### PR TITLE
fix: list numeration in 02-content-safety.md

### DIFF
--- a/Instructions/Labs/02-content-safety.md
+++ b/Instructions/Labs/02-content-safety.md
@@ -18,7 +18,7 @@ The Content Safety Studio enables you to explore how text and image content can 
 
 1. Open the [Content Safety Studio](https://contentsafety.cognitive.azure.com?azure-portal=true). If you are not logged in, you will need to sign in. Select **Sign In** on the top right of the screen. Use the email and password associated with your Azure subscription to sign in. 
 
-1. The Content Safety Studio is set up like many other studios for Azure AI services. On the menu at the top of the screen, click on the icon on the left of *Azure AI*. You will see a drop-down list of other studios designed for development with Azure AI services. You can click on the icon again to hide the list.
+2. The Content Safety Studio is set up like many other studios for Azure AI services. On the menu at the top of the screen, click on the icon on the left of *Azure AI*. You will see a drop-down list of other studios designed for development with Azure AI services. You can click on the icon again to hide the list.
 
 ![A screenshot of the Content Safety Studio's menu with a toggle selection open to switch to other studios.](./media/content-safety/studio-toggle-icon.png)  
 


### PR DESCRIPTION
the list numeration for this file has this minor issue which is not a major problem when rendered as markdown but in the page is wrongly displayed:

![image](https://github.com/MicrosoftLearning/mslearn-ai-fundamentals/assets/35697365/11b3dbea-45eb-4216-9a95-1295f8dc6984)

# Module: [Fundamentals of Azure AI services](https://learn.microsoft.com/en-us/training/modules/fundamentals-azure-ai-services/?WT.mc_id=cloudskillschallenge_3ef5d197-cdef-49bc-a8bc-954bcd9e88cc&ns-enrollment-type=Collection&ns-enrollment-id=moqrtod2e2z7)
## Lab/Demo: [Content Safety Studio](https://contentsafety.cognitive.azure.com/)