### PR TITLE
Update 01-machine-learning.md: use unique job name

### DIFF
--- a/Instructions/Labs/01-machine-learning.md
+++ b/Instructions/Labs/01-machine-learning.md
@@ -45,7 +45,7 @@ Automated machine learning enables you to try multiple algorithms and parameters
 
     **Basic settings**:
 
-    - **Job name**: Job name field should be prepopulated with a unique name. Keep it as is.
+    - **Job name**: Job name field should already be prepopulated with a unique name. Keep it as is.
     - **New experiment name**: `mslearn-bike-rental`
     - **Description**: Automated machine learning for bike rental prediction
     - **Tags**: *none*

--- a/Instructions/Labs/01-machine-learning.md
+++ b/Instructions/Labs/01-machine-learning.md
@@ -45,7 +45,7 @@ Automated machine learning enables you to try multiple algorithms and parameters
 
     **Basic settings**:
 
-    - **Job name**: `mslearn-bike-automl`
+    - **Job name**: Job name field should be prepopulated with a unique name. Keep it as is.
     - **New experiment name**: `mslearn-bike-rental`
     - **Description**: Automated machine learning for bike rental prediction
     - **Tags**: *none*


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 01-machine-learning

Fixes: AutoML job cannot be recreated with the same Job name. Users trying to redo the experiment will see the newer AutoML job failing.

Changes proposed in this pull request: Let users use the prepopulated unique name that is already set by AzureML Studio.
Example prepopulated unique name:
![image](https://github.com/user-attachments/assets/e368e630-e8a9-4880-883f-db54ceea8eb8)

Related: https://github.com/MicrosoftLearning/mslearn-ai-fundamentals/issues/28