### PR TITLE
Update navigation instructions for text analysis exercises

### DIFF
--- a/Instructions/Exercises/03b-text-analysis.md
+++ b/Instructions/Exercises/03b-text-analysis.md
@@ -88,7 +88,7 @@ The **Azure Language in Foundry Tools** provides purpose-built analyzers that us
 
 1. In the Foundry portal, navigate to the menu at the top of the screen and select **Build**.
 
-1. On the *Build* page, navigate to the menu on the left-side of the screen (you may need to expand it). In the menu, select **Deployments**. Then, at the top of the *Deployments* page, select **AI Services**.
+1. On the *Build* page, navigate to the menu on the left-side of the screen (you may need to expand it). In the menu, select **Services**.
 
     Microsoft Foundry Tools includes multiple AI Services (formerly known as Microsoft Cognitive Services) that support common speech, translation, language, and content understanding workloads.
 
@@ -98,7 +98,7 @@ The **Azure Language in Foundry Tools** provides purpose-built analyzers that us
 
 In scenarios where text could potentially be in one of multiple languages, the first step in an analysis workflow is often to determine the primary language so the text can be routed to the most appropriate model or agent for the subsequent processing.
 
-1. In the list of AI services, select the **Azure Language - Language detection** analyzer.
+1. In the list of Services, select the **Azure Language - Language detection** analyzer.
 1. In the **Input text** list, select one of the provided sample documents. Then use the **Detect** button to detect the language in which the sample is written.
 
     ![Screenshot of a detected language in the Playground](./media/language_detection.png)
@@ -122,7 +122,7 @@ In scenarios where text could potentially be in one of multiple languages, the f
 
 To comply with privacy policies and laws, organizations often need to detect and redact **personally identifiable information (PII)** such as names, addresses, phone numbers, email addresses, and other personal details.
 
-1. On the language detection playground page, in the **Type** drop-down list, select **Text PII extraction** (or return to the list of AI services and select **Azure Language - Text PII extraction**).
+1. On the language detection playground page, in the **Type** drop-down list, select **Text PII Redaction** (or return to the list of AI services and select **Azure Language - Text PII Redaction**).
 2. In the **Input text** list, select one of the provided sample documents. Then use the **Detect** button to detect PII values in the text.
 
     ![Screenshot of a detected PII in the Playground](./media/pii_extraction.png)

--- a/Instructions/Exercises/06a-content-understanding.md
+++ b/Instructions/Exercises/06a-content-understanding.md
@@ -38,7 +38,7 @@ This exercise takes approximately **25** minutes.
 ## Use *Content Understanding* to extract information from documents
 
 1. In the Foundry portal, navigate to the tool bar at the top of the screen and select **Build**.
-2. On the *Build* page, in the menu on the left-side of the screen (which you may need to expand), select **Deployments**. Then, at the top of the *Deployments* page, select **AI Services**.
+2. On the *Build* page, in the menu on the left-side of the screen (which you may need to expand), select **Services**.
 3. Select **Content Understanding** to open the *Content Understanding* tool playground.
 
     ![Screenshot of the Content Understanding playground.](./media/content-understanding.png)


### PR DESCRIPTION
This pull request updates instructions in the text analysis and content understanding exercises to align with recent UI changes and service renaming in the Foundry portal. Key changes include updating menu navigation steps and standardizing terminology for service names and analyzer options.

**Navigation and UI terminology updates:**

* Updated instructions to select **Services** instead of **Deployments** -> **AI Services** in the left-side menu and related steps, reflecting changes in the Foundry portal navigation. [[1]](diffhunk://#diff-f33ac6d8aeb31c26e8d91307b193786f375d887700bdc3ac147388b8fec60f27L91-R91) [[2]](diffhunk://#diff-7a2bc719f3c62b67481cc3bc5fc0757549d6d1029bd495a6b5959537343a602aL41-R41)
* Changed references from "AI services" to "Services" when selecting analyzers within the portal.

**Service and analyzer naming consistency:**

* Updated analyzer option from **Text PII extraction** to **Text PII Redaction** in both the drop-down and service selection instructions, ensuring consistency with the current naming in the portal.