### PR TITLE
Fix incorrect response property in 02a-generative-ai.md

### DIFF
--- a/Instructions/Exercises/02a-generative-ai.md
+++ b/Instructions/Exercises/02a-generative-ai.md
@@ -100,7 +100,7 @@ When you're satisfied with the responses a model returns in the playground, you 
         input="What is the capital of France?",
    )
     
-   print(f"answer: {response.output[0]}")
+   print(f"answer: {response.output_text}")
     ```
 
     The code connects to the **OpenAI** endpoint for your Microsoft Foundry resource, using its secret authentication key (which you would need to copy into the code to set the **api_key** variable). It then uses the **responses.create** method to generate a response from your deployed model from an input prompt (in this case, the hard-coded question "What is the capital of France?") and prints the response to the output console.


### PR DESCRIPTION
Line 103 of `Instructions/Exercises/02a-generative-ai.md` prints `response.output[0]`, which returns the raw first item of the `output` array. Depending on the model, this can be a `ResponseReasoningItem` (as with reasoning-capable models like gpt-5-mini) rather than the actual answer text, producing output like: answer: ResponseReasoningItem(id='rs_0ec1dc0ed9fd729a006a5b86cbf370819782dc6149cc7c3173', summary=[], type='reasoning', content=[], encrypted_content=None, status=None) instead of the expected answer to "What is the capital of France?". ## Fix
Use the OpenAI SDK's `output_text` convenience property instead, which correctly aggregates the response's text content:
```python
print(f"answer: {response.output_text}")

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-